### PR TITLE
Adds the layercount to the VulkanTexture and SwapChainBundle

### DIFF
--- a/filament/backend/include/backend/platforms/VulkanPlatform.h
+++ b/filament/backend/include/backend/platforms/VulkanPlatform.h
@@ -21,6 +21,7 @@
 
 #include <bluevk/BlueVK.h>
 
+#include <cstdint>
 #include <utils/CString.h>
 #include <utils/FixedCapacityVector.h>
 #include <utils/Hash.h>
@@ -88,6 +89,7 @@ public:
         VkFormat colorFormat = VK_FORMAT_UNDEFINED;
         VkFormat depthFormat = VK_FORMAT_UNDEFINED;
         VkExtent2D extent = {0, 0};
+        uint8_t layerCount = 1;
         bool isProtected = false;
     };
 
@@ -302,6 +304,11 @@ public:
          * The height of the external image
          */
         uint32_t height;
+
+        /**
+         * The layerCount of the external image
+         */
+        uint8_t layerCount;
 
         /**
          * The layer count of the external image

--- a/filament/backend/src/vulkan/VulkanDriver.cpp
+++ b/filament/backend/src/vulkan/VulkanDriver.cpp
@@ -561,7 +561,7 @@ void VulkanDriver::createTextureExternalImageR(Handle<HwTexture> th,
 
     auto texture = resource_ptr<VulkanTexture>::make(&mResourceManager, th, mPlatform->getDevice(),
         mAllocator, &mResourceManager, &mCommands, data.first, data.second, metadata.format,
-        1, metadata.width, metadata.height, usage, mStagePool);
+        1, metadata.width, metadata.height, metadata.layerCount, usage, mStagePool);
 
     texture.inc();
 }

--- a/filament/backend/src/vulkan/VulkanHandles.cpp
+++ b/filament/backend/src/vulkan/VulkanHandles.cpp
@@ -274,20 +274,26 @@ void VulkanRenderTarget::bindToSwapChain(fvkmemory::resource_ptr<VulkanSwapChain
 
     VulkanAttachment color = {};
     color.texture = swapchain->getCurrentColor();
+    if (color.texture) {
+      color.layerCount = color.texture->getPrimaryViewRange().layerCount;
+    }
     mInfo->attachments = {color};
 
     auto& fbkey = mInfo->fbkey;
     auto& rpkey = mInfo->rpkey;
 
     rpkey.colorFormat[0] = color.getFormat();
+    rpkey.viewCount = color.layerCount;
     fbkey.width = width;
     fbkey.height = height;
+    fbkey.layers = color.layerCount;
     fbkey.color[0] = color.getImageView();
     fbkey.resolve[0] = VK_NULL_HANDLE;
 
     if (swapchain->getDepth()) {
         VulkanAttachment depth = {};
         depth.texture = swapchain->getDepth();
+        depth.layerCount = depth.texture->getPrimaryViewRange().layerCount;
         mInfo->attachments.push_back(depth);
         mInfo->depthIndex = 1;
 

--- a/filament/backend/src/vulkan/VulkanSwapChain.cpp
+++ b/filament/backend/src/vulkan/VulkanSwapChain.cpp
@@ -76,14 +76,14 @@ void VulkanSwapChain::update() {
     for (auto const color: bundle.colors) {
         auto colorTexture = fvkmemory::resource_ptr<VulkanTexture>::construct(mResourceManager,
                 device, mAllocator, mResourceManager, mCommands, color, VK_NULL_HANDLE,
-                bundle.colorFormat, 1, bundle.extent.width, bundle.extent.height, colorUsage,
+                bundle.colorFormat, 1, bundle.extent.width, bundle.extent.height, bundle.layerCount, colorUsage,
                 mStagePool);
         mColors.push_back(colorTexture);
     }
 
     mDepth = fvkmemory::resource_ptr<VulkanTexture>::construct(mResourceManager, device,
         mAllocator, mResourceManager, mCommands, bundle.depth, VK_NULL_HANDLE,
-        bundle.depthFormat, 1, bundle.extent.width, bundle.extent.height, depthUsage,
+        bundle.depthFormat, 1, bundle.extent.width, bundle.extent.height, bundle.layerCount, depthUsage,
         mStagePool);
 
     mExtent = bundle.extent;

--- a/filament/backend/src/vulkan/VulkanTexture.cpp
+++ b/filament/backend/src/vulkan/VulkanTexture.cpp
@@ -165,12 +165,12 @@ VulkanTextureState::VulkanTextureState(VkDevice device, VmaAllocator allocator,
 VulkanTexture::VulkanTexture(VkDevice device, VmaAllocator allocator,
         fvkmemory::ResourceManager* resourceManager, VulkanCommands* commands, VkImage image,
         VkDeviceMemory memory, VkFormat format, uint8_t samples, uint32_t width,
-        uint32_t height, TextureUsage tusage, VulkanStagePool& stagePool)
+        uint32_t height, uint8_t layerCount, TextureUsage tusage, VulkanStagePool& stagePool)
     : HwTexture(SamplerType::SAMPLER_2D, 1, samples, width, height, 1, TextureFormat::UNUSED,
               tusage),
       mState(fvkmemory::resource_ptr<VulkanTextureState>::construct(resourceManager, device,
               allocator, commands, stagePool, format, imgutil::getViewType(SamplerType::SAMPLER_2D),
-              1, 1, getDefaultLayoutImpl(tusage), any(usage & TextureUsage::PROTECTED))) {
+              1, layerCount, getDefaultLayoutImpl(tusage), any(usage & TextureUsage::PROTECTED))) {
     mState->mTextureImage = image;
     mState->mTextureImageMemory = memory;
     mPrimaryViewRange = mState->mFullViewRange;

--- a/filament/backend/src/vulkan/VulkanTexture.h
+++ b/filament/backend/src/vulkan/VulkanTexture.h
@@ -24,6 +24,7 @@
 #include "vulkan/memory/Resource.h"
 #include "vulkan/memory/ResourcePointer.h"
 
+#include <cstdint>
 #include <utils/Hash.h>
 #include <utils/RangeMap.h>
 
@@ -94,7 +95,7 @@ struct VulkanTexture : public HwTexture, fvkmemory::Resource {
     // The texture will never destroy the given VkImage, but it does manages its subresources.
     VulkanTexture(VkDevice device, VmaAllocator allocator,
             fvkmemory::ResourceManager* resourceManager, VulkanCommands* commands, VkImage image,
-            VkDeviceMemory memory, VkFormat format, uint8_t samples, uint32_t width, uint32_t height,
+            VkDeviceMemory memory, VkFormat format, uint8_t samples, uint32_t width, uint32_t height, uint8_t layerCount,
             TextureUsage tusage, VulkanStagePool& stagePool);
 
     // Constructor for creating a texture view for wrt specific mip range


### PR DESCRIPTION
Adds the layercount to the VulkanTexture and SwapChainBundle so that externally created SwapChainImages have the proper number of layers.